### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - yyyy-mm-dd
 
+## [1.0.0] - 2025-07-29
 Initial version.
+
+Contains the following features:
+- `@IncludeOnEnv` and `@ExcludeOnEnv` annotations for conditional test execution.
+- `IncludeOnEnvListener` and `ExcludeOnEnvListener` to handle these annotations.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.cpjust</groupId>
     <artifactId>testng-annotations</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>testng-annotations</name>
     <description>Contains some extra annotations that are useful when running tests in TestNG.</description>
     <url>https://github.com/cpjust/testng-annotations</url>


### PR DESCRIPTION
I tested using 1.0.0-SNAPSHOT as a dependency and was able to download it from sonatype and use it in another project by adding this to the pom.xml, so release version should also work.

```xml
<repositories>
    <repository>
        <id>sonatype-snapshot-repo</id>
        <name>Sonatype Central Snapshot Repository</name>
        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
        <releases>
            <enabled>false</enabled>
        </releases>
        <snapshots>
            <enabled>true</enabled>
        </snapshots>
    </repository>
</repositories>
```